### PR TITLE
feat: add pprof profiling endpoint and rtu-over-tcp support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] - 2026-05-13
+
+### Added
+
+- pprof Profiling Endpoint: Integrated Go's built-in `net/http/pprof` handler, exposing a dedicated HTTP server for runtime profiling. This enables CPU profiling, memory heap analysis, goroutine inspection, and other diagnostics via the standard `go tool pprof` toolchain.
+
+## [0.3.0] - 2026-01-15
 
 ### Added
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] - 2026-05-13
+
+### Added
+
+- pprof 性能剖析端点：集成了 Go 内置的 `net/http/pprof` 处理器，暴露独立的 HTTP 服务用于运行时性能分析。支持通过标准 `go tool pprof` 工具链进行 CPU 剖析、内存堆分析、Goroutine 检查等诊断操作。
+
+## [0.3.0] - 2026-01-15
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -364,40 +364,53 @@ Use the `-config` flag to specify the configuration file path:
  
  ### Configuration Structure
  
- The configuration file supports defining multiple gateways (`gateways`). Each gateway can have multiple upstream masters (`upstreams`) and one downstream slave (`downstream`).
+ The configuration file supports defining multiple gateways (`gateways`). Each gateway can have multiple upstream masters (`upstreams`) and one or more downstream slaves (`downstreams`). Use the `slave_ids` field on each downstream to define routing rules — requests whose Slave ID matches are forwarded to that downstream. 
  
  #### Example `config.yaml`
  
  ```yaml
+ pprof:
+   enabled: false
+   address: "localhost:6060"
+
  gateways:
    - name: "gateway-1"
-     # Upstream: Who connects to the gateway (Modbus Masters)
+     # Upstreams: Who connects to the gateway (Modbus Masters)
      upstreams:
        - type: "tcp"
          tcp:
            address: "0.0.0.0:502"
-     # Downstream: Who the gateway connects to (Modbus Slave)
-     downstream:
-       type: "rtu"
-       serial:
-         device: "/dev/ttyUSB0"
-         baud_rate: 19200
-         data_bits: 8
-         parity: "N"
-         stop_bits: 1
-         timeout: "500ms"
- 
+     # Downstreams: Who the gateway connects to (Modbus Slaves)
+     # slave_ids supports single values ("1"), comma-separated lists ("1,2,3"),
+     # and ranges ("1-10").
+     downstreams:
+       - type: "rtu"
+         slave_ids: "1-10"      # Route Slave ID 1~10 to this RTU device
+         serial:
+           device: "/dev/ttyUSB0"
+           baud_rate: 19200
+           data_bits: 8
+           parity: "N"
+           stop_bits: 1
+           timeout: "500ms"
+       - type: "local"
+         slave_ids: "100"       # Route Slave ID 100 to the built-in local slave
+         local:
+           persistence:
+             type: "mmap"
+             path: "/data/"
+
    # Example: Another gateway instance, TCP to TCP bridge
    - name: "gateway-tcp-bridge"
      upstreams:
        - type: "tcp"
          tcp:
            address: "0.0.0.0:503"
-     downstream:
-       type: "tcp"
-       tcp:
-         address: "192.168.1.100:502"
- 
+     downstreams:
+       - type: "tcp"
+         tcp:
+           address: "192.168.1.100:502"
+
  log:
    level: "info" # debug, info, warn, error
    file: ""      # empty for stdout

--- a/README_CN.md
+++ b/README_CN.md
@@ -363,11 +363,15 @@ go build
  
 ### 配置文件结构
  
-配置文件支持定义多个网关 (`gateways`)。每个网关可以有多个上游主站 (`upstreams`) 和一个下游从站 (`downstream`)。
+配置文件支持定义多个网关 (`gateways`)。每个网关可以有多个上游主站 (`upstreams`) 和一个或多个下游从站 (`downstreams`)。通过每个下游的 `slave_ids` 字段定义路由规则——Slave ID 匹配的请求将被转发到该下游。
  
  #### 示例 `config.yaml`
  
  ```yaml
+ pprof:
+   enabled: false
+   address: "localhost:6060"
+
  gateways:
    - name: "gateway-1"
      # 上游: 谁连接到网关 (Modbus Masters)
@@ -375,28 +379,36 @@ go build
        - type: "tcp"
          tcp:
            address: "0.0.0.0:502"
-     # 下游: 网关连接到谁 (Modbus Slave)
-     downstream:
-       type: "rtu"
-       serial:
-         device: "/dev/ttyUSB0"
-         baud_rate: 19200
-         data_bits: 8
-         parity: "N"
-         stop_bits: 1
-         timeout: "500ms"
- 
+     # 下游: 网关连接到谁 (Modbus Slaves)
+     # slave_ids 支持单个值 ("1")、逗号分隔列表 ("1,2,3") 和范围 ("1-10")
+     downstreams:
+       - type: "rtu"
+         slave_ids: "1-10"      # 将 Slave ID 1~10 的请求路由到此 RTU 设备
+         serial:
+           device: "/dev/ttyUSB0"
+           baud_rate: 19200
+           data_bits: 8
+           parity: "N"
+           stop_bits: 1
+           timeout: "500ms"
+       - type: "local"
+         slave_ids: "100"       # 将 Slave ID 100 的请求路由到内置本地从站
+         local:
+           persistence:
+             type: "mmap"
+             path: "/data/"
+
    # 示例: 另一个网关实例，TCP 转 TCP
    - name: "gateway-tcp-bridge"
      upstreams:
        - type: "tcp"
          tcp:
            address: "0.0.0.0:503"
-     downstream:
-       type: "tcp"
-       tcp:
-         address: "192.168.1.100:502"
- 
+     downstreams:
+       - type: "tcp"
+         tcp:
+           address: "192.168.1.100:502"
+
  log:
    level: "info" # debug, info, warn, error
    file: ""      # 为空输出到控制台

--- a/config.yaml
+++ b/config.yaml
@@ -1,17 +1,37 @@
+pprof:
+  enabled: false
+  address: "localhost:6060"
+
 gateways:
-  - name: "test-gateway"
+  - name: "modbus-slave"
+    # Upstreams: Who connects to the gateway (Modbus Masters)
     upstreams:
       - type: "tcp"
         tcp:
           address: "0.0.0.0:33502"
-    downstream:
-      type: "rtu"
-      serial:
-        device: "/tmp/pts0"
-        baud_rate: 19200
-        data_bits: 8
-        parity: "N"
-        stop_bits: 1
-        timeout: "1s"
+      - type: "rtu-over-tcp"
+        tcp:
+          address: "0.0.0.0:502"
+    # Downstreams: Who the gateway connects to (Modbus Slave)
+    downstreams:
+      - type: "local"
+        slave_ids: "100"    # Route `SlaveID=100` packets to this gateway
+        local:
+          persistence:
+            type: "mmap"
+            path: "/data/"
+
+  # Example: another gateway instance, TCP proxy (TCP to TCP)
+  - name: "gateway-tcp-bridge"
+    upstreams:
+      - type: "tcp"
+        tcp:
+          address: "0.0.0.0:503"
+    downstreams:
+      - type: "tcp"
+        tcp:
+          address: "192.168.1.100:502"
+
 log:
-  level: "debug"
+  level: "info" # debug, info, warn, error
+  file: ""      # If empty, output to the console.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,17 +33,17 @@ type GatewayConfig struct {
 
 // UpstreamConfig defines a master connecting to the gateway
 type UpstreamConfig struct {
-	Type   string       `mapstructure:"type"`   // "tcp" or "rtu"
-	Tcp    TcpConfig    `mapstructure:"tcp"`    // Used if Type is "tcp"
+	Type   string       `mapstructure:"type"`   // "tcp", "rtu", "rtu-over-tcp"
+	Tcp    TcpConfig    `mapstructure:"tcp"`    // Used if Type is "tcp" or "rtu-over-tcp"
 	Serial SerialConfig `mapstructure:"serial"` // Used if Type is "rtu"
 }
 
 // DownstreamConfig defines the slave the gateway connects to
 type DownstreamConfig struct {
 	Name     string       `mapstructure:"name"`      // Optional name for logging
-	Type     string       `mapstructure:"type"`      // "tcp", "rtu", or "local"
+	Type     string       `mapstructure:"type"`      // "tcp", "rtu", "rtu-over-tcp", "local"
 	SlaveIDs string       `mapstructure:"slave_ids"` // Routing rules: "1", "1,2", "1-10"
-	Tcp      TcpConfig    `mapstructure:"tcp"`       // Used if Type is "tcp"
+	Tcp      TcpConfig    `mapstructure:"tcp"`       // Used if Type is "tcp" or "rtu-over-tcp"
 	Serial   SerialConfig `mapstructure:"serial"`    // Used if Type is "rtu"
 	Local    LocalConfig  `mapstructure:"local"`     // Used if Type is "local"
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,12 +16,19 @@ import (
 type Config struct {
 	Gateways []GatewayConfig `mapstructure:"gateways"`
 	Log      LogConfig       `mapstructure:"log"`
+	Pprof    PprofConfig     `mapstructure:"pprof"`
 }
 
 // LogConfig defines logging configuration
 type LogConfig struct {
 	Level string `mapstructure:"level"` // debug, info, warn, error
 	File  string `mapstructure:"file"`  // Log file path
+}
+
+// PprofConfig defines pprof configuration
+type PprofConfig struct {
+	Enabled bool   `mapstructure:"enabled"`
+	Address string `mapstructure:"address"` // e.g. "localhost:6060"
 }
 
 // GatewayConfig defines a single gateway instance

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ffutop/modbus-gateway/transport"
 	"github.com/ffutop/modbus-gateway/transport/local"
 	"github.com/ffutop/modbus-gateway/transport/rtu"
+	rtuovertcp "github.com/ffutop/modbus-gateway/transport/rtu-over-tcp"
 	"github.com/ffutop/modbus-gateway/transport/tcp"
 )
 
@@ -102,6 +103,8 @@ func main() {
 				us = tcp.NewServer(usCfg.Tcp.Address)
 			case "rtu":
 				us = rtu.NewServer(usCfg.Serial)
+			case "rtu-over-tcp":
+				us = rtuovertcp.NewServer(usCfg.Tcp.Address)
 			default:
 				slog.Error("Unknown upstream type", "type", usCfg.Type, "gateway", gwCfg.Name)
 				continue
@@ -147,6 +150,8 @@ func createDownstream(cfg config.DownstreamConfig) (transport.Downstream, error)
 		return tcp.NewClient(cfg.Tcp.Address), nil
 	case "rtu":
 		return rtu.NewClient(cfg.Serial), nil
+	case "rtu-over-tcp":
+		return rtuovertcp.NewClient(cfg.Tcp.Address), nil
 	case "local":
 		return local.NewClient(cfg.Local), nil
 	default:

--- a/main.go
+++ b/main.go
@@ -9,6 +9,8 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"net/http"
+	_ "net/http/pprof" // Register pprof handlers
 	"os"
 	"os/signal"
 	"sync"
@@ -35,6 +37,19 @@ func main() {
 	}
 
 	setupLogger(cfg.Log)
+
+	if cfg.Pprof.Enabled {
+		addr := cfg.Pprof.Address
+		if addr == "" {
+			addr = "localhost:6060"
+		}
+		go func() {
+			slog.Info("Starting pprof server", "addr", addr)
+			if err := http.ListenAndServe(addr, nil); err != nil {
+				slog.Error("Failed to start pprof server", "err", err)
+			}
+		}()
+	}
 
 	slog.Info("Starting Modbus Gateway...")
 
@@ -139,6 +154,7 @@ func main() {
 	<-sigChan
 
 	slog.Info("Shutting down...")
+
 	cancel()
 	wg.Wait()
 	slog.Info("Goodbye.")


### PR DESCRIPTION
  - Integrate net/http/pprof for runtime CPU/memory/goroutine profiling
  - Support rtu-over-tcp type in upstream and downstream configurations
  - Add v0.4.0 changelog entry (EN/CN)
  - Fix README (EN/CN) config examples: downstream → downstreams array,
    add slave_ids routing field, include pprof top-level section
  - Update config.yaml sample to reflect current schema